### PR TITLE
Little apostrophe typo in MIRROR.md

### DIFF
--- a/provisioning/baremetal/MIRROR.md
+++ b/provisioning/baremetal/MIRROR.md
@@ -62,7 +62,7 @@ create_mirror_hdp.sh
 
 Note that, as above, the deb and rpm scripts are for use on Ubuntu or RHEL hosts respectively.
 
-Each script creates it's output in a directory named for the respective mirror type -
+Each script creates its output in a directory named for the respective mirror type -
 
 ```
 mirror_deb


### PR DESCRIPTION
Just removing a quick typo found in MIRROR.md in the bare metal guide.
"Each script creates its output [...]"
'Its' is used as a possessive, as 'output' belongs to 'script'.
Have a nice day :)