### PR TITLE
Update documentation for removal of pam_module pillar

### DIFF
--- a/console/uicredentials.md
+++ b/console/uicredentials.md
@@ -17,14 +17,14 @@ The PNDA console "metrics" page also contains a list of links to various UIs.
  - (HDP only) Ambari: admin/admin
  - Grafana: pnda/pndapnda
  - Jupyter:
-    - dev1/dev1, prod1/prod1 (when using the default pam_module: 'pam_unix' authentication) 
+    - dev1/dev1, prod1/prod1 (when using the default non-LDAP PAM authentication) 
  - Everything else:  pnda/pnda
 
 ## Setting Credentials
 If different passwords are required they can be configured in the platform-salt configuration before provisioning PNDA:
  - The Cloudera Manager credentials are located in [platform-salt/pillar/services.sls:admin_login](https://github.com/pndaproject/platform-salt/blob/develop/pillar/services.sls)
  - The PNDA user credentials are located in [platform-salt/pillar/pnda.sls:pnda](https://github.com/pndaproject/platform-salt/blob/develop/pillar/pnda.sls)
- - The Jupyter user credentials (when using  the default pam_module: 'pam_unix' authentication) are located in [platform-salt/pillar/identity.sls](https://github.com/pndaproject/platform-salt/blob/develop/pillar/identity.sls)
+ - The Jupyter user credentials (when using the default non-LDAP PAM authentication) are located in [platform-salt/pillar/identity.sls](https://github.com/pndaproject/platform-salt/blob/develop/pillar/identity.sls)
 
 Note that for the PNDA user `password_hash` should be set along with the `user` and `password`. The easiest and most reliable way to do this is to set the password on a RHEL 7 machine, then look in /etc/shadow for the password hash.
 


### PR DESCRIPTION
Update documentation to reflect the removal of the pam_module pillar setting. pam_unix is no longer enabled explicitly, and remains the default option.

PNDA-4598