### PR TITLE
Change the gobblin repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The PNDA distribution consists of the following source code repositories and sub
    * [hdfs-cleaner](http://github.com/pndaproject/platform-data-mgmnt/tree/master/hdfs-cleaner): cron job to clean up HDFS data
    * [oozie-templates](http://github.com/pndaproject/platform-data-mgmnt/tree/master/oozie-templates): templates that archive or delete data
  * [platform-package-repository](http://github.com/pndaproject/platform-package-repository): manages a simple package repository backed by OpenStack Swift
- * [gobblin](http://github.com/pndaproject/gobblin): customized fork of the Gobblin data ingest framework
+ * [gobblin](https://github.com/pndaproject/platform-gobblin-modules): customized fork of the Gobblin data ingest framework
 
 ### Producers
 

--- a/console/datasets.md
+++ b/console/datasets.md
@@ -22,7 +22,7 @@ After you have made changes, click the Save button to review and confirm the cha
 
 ## Creating datasets
 
-Datasets are automatically created based on the name of the `source` field in Kafka messages by [gobblin](https://github.com/pndaproject/gobblin). See the [getting started](../gettingstarted/README.md#producer-integration) for more information on how datasets are created.  
+Datasets are automatically created based on the name of the `source` field in Kafka messages by [gobblin](https://github.com/pndaproject/platform-gobblin-modules). See the [getting started](../gettingstarted/README.md#producer-integration) for more information on how datasets are created.  
 
 ## Dataset Compaction
 

--- a/gettingstarted/README.md
+++ b/gettingstarted/README.md
@@ -37,7 +37,7 @@ For the purposes of this guide, we'll use the test data source for the example [
 3. Install and configure [Logstash](https://github.com/elastic/logstash) on the chosen host then install the following [plugin](../producer/logstash.md).
 4. Run the test data script. In the `data-source` directory of the [example-spark-streaming](https://github.com/pndaproject/example-applications/tree/master/spark-streaming) repository, there is a python script that can send a stream of data over TCP into logstash. 
 5. In the [console](../console/README.md), verify that data is flowing into the topics. In the left-hand column, you should see activity on your Kafka topic.
-6. After a period of time (up to 30 minutes), the master dataset will be automatically created by [gobblin](https://github.com/pndaproject/gobblin), and you will be able to see it in the [Datasets](../console/datasets.md) page in the console.
+6. After a period of time (up to 30 minutes), the master dataset will be automatically created by [gobblin](https://github.com/pndaproject/platform-gobblin-modules), and you will be able to see it in the [Datasets](../console/datasets.md) page in the console.
 
 ## Packages and applications
 

--- a/repos/README.md
+++ b/repos/README.md
@@ -29,7 +29,7 @@ It consists of the following source code repositories and sub-projects:
    * [hdfs-cleaner](http://github.com/pndaproject/platform-data-mgmnt/tree/master/hdfs-cleaner): cron job to clean up HDFS data
    * [oozie-templates](http://github.com/pndaproject/platform-data-mgmnt/tree/master/oozie-templates): templates that archive or delete data
  * [platform-package-repository](http://github.com/pndaproject/platform-package-repository): manages a simple package repository backed by OpenStack Swift
- * [gobblin](http://github.com/pndaproject/gobblin): customized fork of the Gobblin data ingest framework
+ * [gobblin](https://github.com/pndaproject/platform-gobblin-modules): customized fork of the Gobblin data ingest framework
 
 ### Producers
 


### PR DESCRIPTION
Currently, gobblin link points to the deprecated repo. 
Should points to 'platform-gobblin-modules' repo.